### PR TITLE
Bug Fixes

### DIFF
--- a/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
@@ -131,7 +131,7 @@ long MCP3428::readADC()
                     raw_adc = raw_adc - 4096;
                 }
         
-                // raw_adc = raw_adc*1000/GAIN;
+                raw_adc = raw_adc*1000/GAIN;
         
                 break;
     
@@ -146,7 +146,7 @@ long MCP3428::readADC()
                     raw_adc = raw_adc - 16384;
                 }
         
-                // raw_adc = raw_adc*250/GAIN;
+                raw_adc = raw_adc*250/GAIN;
        
                 break;
     
@@ -161,7 +161,7 @@ long MCP3428::readADC()
                     raw_adc = raw_adc - 65536;
                 }
 
-                // raw_adc = raw_adc*62.5/GAIN;
+                raw_adc = raw_adc*62.5/GAIN;
       
                 break;
     }

--- a/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
@@ -1,12 +1,10 @@
 /****************************************************************************
- /*
  Distributed with a free-will license.
  Use it any way you want, profit or free, provided it fits in the licenses of its associated works.
  MCP3428
  This code is designed to work with the MCP3428_I2CADC I2C Mini Module available from ControlEverything.com.
  https://www.controleverything.com/content/Analog-Digital-Converters?sku=MCP3428_I2CADC#tabs-0-product_tabset-2
- */
-/****************************************************************************/
+****************************************************************************/
 
 #include <Wire.h>
 #include <MCP3428.h>

--- a/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
@@ -115,7 +115,15 @@ long MCP3428::readADC()
 
     raw_adc = 0;
 
-    while(CheckConversion() == 1);
+    while(CheckConversion() == 1) {
+        unsigned long convTime = getConversionTime(SPS);
+        if (convTime > 16383) {
+            convTime /= 1000;
+            delay(convTime);
+        } else { 
+            delayMicroseconds(convTime);
+        }
+    }
 
     switch (SPS)
     {
@@ -166,4 +174,19 @@ long MCP3428::readADC()
                 break;
     }
     return raw_adc;
+}
+
+unsigned long MCP3428::getConversionTime(uint8_t resolution) {
+  switch (resolution) {
+    case 12:
+      return 4167; // 240 SPS
+    case 14:
+      return 16667; // 60 SPS
+    case 16:
+      return 66667; // 15 SPS
+    case 18:
+      return 266667; // 3.75 SPS
+    default:
+      return 0;
+  }
 }

--- a/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
@@ -114,8 +114,8 @@ long MCP3428::readADC()
 {
 
     raw_adc = 0;
-
-    while(CheckConversion() == 1) {
+    int tries = 0;
+    while(CheckConversion() == 1 && tries++ < 5) {
         unsigned long convTime = getConversionTime(SPS);
         if (convTime > 16383) {
             convTime /= 1000;

--- a/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.cpp
@@ -17,7 +17,7 @@
 MCP3428::MCP3428(uint8_t devAddress)
 {
     Wire.begin();
-    devAddr = 1101<<3;
+    devAddr = 0x68;
     devAddr |= devAddress;
 }
 

--- a/Arduino/MCP3428_Arduino_Library/MCP3428.h
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.h
@@ -1,12 +1,10 @@
 /****************************************************************************
-/*
         Distributed with a free-will license.
         Use it any way you want, profit or free, provided it fits in the licenses of its associated works.
         MCP3428
         This code is designed to work with the MCP3428_I2CADC I2C Mini Module available from ControlEverything.com.
         https://www.controleverything.com/content/Analog-Digital-Converters?sku=MCP3428_I2CADC#tabs-0-product_tabset-2
- */
-/****************************************************************************/
+****************************************************************************/
 
 #include <Wire.h>
 #include <math.h>

--- a/Arduino/MCP3428_Arduino_Library/MCP3428.h
+++ b/Arduino/MCP3428_Arduino_Library/MCP3428.h
@@ -21,6 +21,7 @@ class MCP3428
         long readADC();
 
     private:
+        unsigned long getConversionTime(uint8_t resolution);
 
         uint8_t devAddr;
         long raw_adc;


### PR DESCRIPTION
Bug Fixes
- "/*" was removed from comments, as it led to a compilation errors
- Convert devAddr to hex to reflect address from datasheet
- Multiply raw ADC values by LSB to get correct scaling
- Delay between checks of conversion to prevent I2C invalid bus state warning